### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: Create a job summary
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/sinsukehlab/NOTE-test/security/code-scanning/1](https://github.com/sinsukehlab/NOTE-test/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (before the `jobs` section) to explicitly define the least privileges required. Since the workflow only reads the repository contents, we will set `contents: read`. This ensures that the workflow adheres to the principle of least privilege and does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
